### PR TITLE
Added database index on test_results.test_date

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -11,6 +11,8 @@ CREATE TABLE test_results
 , error TEXT
 );
 
+CREATE INDEX test_results_by_date ON test_results (test_date);
+
 CREATE TABLE srv_results
 ( srv_result_id SERIAL UNIQUE
 , test_id INTEGER REFERENCES test_results(test_id)


### PR DESCRIPTION
xmpp.net/list.php is pretty slow. The first query that it performs, is:

    SELECT * FROM test_results ORDER BY test_date DESC LIMIT 200

I am assuming that this query is underperforming, as the amount of rows in that table is probably pretty large. An index should help. Untested/unverified though.